### PR TITLE
Bump dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,10 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Distributions = "~0.21"
-Optim = "~0.19"
-SpecialFunctions = "~0.8"
-julia = "~1"
+julia = "1"
+Distributions = "0.21"
+Optim = "0.20"
+SpecialFunctions = "0.8"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"


### PR DESCRIPTION
Bump Optim dependency to avoid warning as happened in StateSpaceModels, remove upper bounds