### PR TITLE
fix poisson fisher access

### DIFF
--- a/src/distributions/poisson.jl
+++ b/src/distributions/poisson.jl
@@ -20,7 +20,7 @@ function score!(score_til::Matrix{T}, y::Int, ::Type{Poisson}, param::Matrix{T},
 end
 
 function fisher_information!(aux::AuxiliaryLinAlg{T}, ::Type{Poisson}, param::Matrix{T}, t::Int) where T
-    aux.fisher[1, 1] = 1/param[1]
+    aux.fisher[1, 1] = 1/param[t, 1]
     return
 end
 


### PR DESCRIPTION
In the calculation of the fisher information of the Poisson distribution, the t index was missing in the matrix params